### PR TITLE
Extending rss parsing for rough Podcast support

### DIFF
--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -55,7 +55,7 @@ class Parser:
                 "description_images": [
                     {"alt": image.get("alt", ""), "source": image.get("src")}
                     for image in description_soup.findAll('img')
-                ]
+                ],
                 "enclosure": {
                         'content': '',
                         'attrs': {

--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -15,6 +15,17 @@ class Parser:
     def get_soup(xml: str, parser: str = "xml") -> BeautifulSoup:
         return BeautifulSoup(xml, parser)
 
+    @staticmethod
+    def check_none(item: object, default: str, item_dict: Optional[str] = None, default_dict: Optional[str] = None):
+        if item:
+            return item[item_dict]
+        else:
+            if default_dict:
+                return default[default_dict]
+            else:
+                return default
+
+
     def parse(self) -> RSSFeed:
         main_soup = self.get_soup(self.xml)
         self.raw_data = {
@@ -45,6 +56,25 @@ class Parser:
                     {"alt": image.get("alt", ""), "source": image.get("src")}
                     for image in description_soup.findAll('img')
                 ]
+                "enclosure": {
+                        'content': '',
+                        'attrs': {
+                             'url': item.enclosure['url'] ,
+                             'length': item.enclosure['length'] ,
+                             'type': item.enclosure['type']
+                            }
+                },
+                "itunes": {
+                    'content': '',
+                    'attrs': {
+                        'href': self.check_none(
+                            item.find("itunes:image"),
+                            main_soup.find("itunes:image"),
+                            'href',
+                            'href'
+                            )
+                    }
+                }
             }
             self.raw_data["feed"].append(item_dict)
 

--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from typing import Optional
 
 from .models import RSSFeed
 

--- a/rss_parser/models.py
+++ b/rss_parser/models.py
@@ -2,11 +2,25 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+class ItunesAttrs(BaseModel):
+    href: str
+
+class Itunes(BaseModel):
+    content: str
+    attrs: Optional[ItunesAttrs]
+
+class EnclosureAttrs(BaseModel):
+    url: str
+    length: int
+    type: str
+
+class Enclosure(BaseModel):
+    content: str
+    attrs: Optional[EnclosureAttrs]
 
 class DescriptionImage(BaseModel):
     alt: Optional[str]
     source: str
-
 
 class FeedItem(BaseModel):
     title: str
@@ -16,7 +30,16 @@ class FeedItem(BaseModel):
     description: str
     description_links: Optional[List[str]]
     description_images: Optional[List[DescriptionImage]]
+    enclosure: Optional[Enclosure]
+    itunes: Optional[Itunes]
 
+    # https://stackoverflow.com/questions/10994229/how-to-make-an-object-properly-hashable#answer-38259091
+    # added this, so you can call/use in a set() on the FeedItem's to ensure no duplicates in a list.
+    def __hash__(self):
+        return hash(self.title.strip())
+
+    def __eq__(self,other):
+        return self.title.strip() == other.title.strip()
 
 class RSSFeed(BaseModel):
     title: str
@@ -24,3 +47,4 @@ class RSSFeed(BaseModel):
     language: Optional[str]
     description: Optional[str]
     feed: List[FeedItem]
+

--- a/rss_parser/models.py
+++ b/rss_parser/models.py
@@ -47,4 +47,3 @@ class RSSFeed(BaseModel):
     language: Optional[str]
     description: Optional[str]
     feed: List[FeedItem]
-


### PR DESCRIPTION
Hello, thanks for this awesome project! :slightly_smiling_face: 

I recently used it as a part of grabbing and parsing rss feeds in one of [my projects](https://github.com/elreydetoda/all-linux-tings/blob/896206bc4beda886a8fb328f9cdbcb28957eb1eb/apis/rssaggregator/app/), and while using it I ended up adding [some overrides](https://github.com/elreydetoda/all-linux-tings/blob/896206bc4beda886a8fb328f9cdbcb28957eb1eb/apis/rssaggregator/app/parser_override.py) for the parser. Just so I could access specific values for the podcasts ( i.e. where to find their media to play, and their cover art for the episode ( which defaults to the overarching cover art of the podcast if there isn't one ) ).

There might be a more official way to grab the image, but I couldn't figure one out ( not really a python dev, and definitely not very acquainted with xml & parsing ). So, you might want to look this section over

https://github.com/elreydetoda/rss-parser/blob/ccae7b9eb92af958da3d118424025558a90c9272/rss_parser/_parser.py#L18-L26

and it was added because of this section:

https://github.com/elreydetoda/rss-parser/blob/ccae7b9eb92af958da3d118424025558a90c9272/rss_parser/_parser.py#L70-L75

This definitely comprehensive podcast support, but I was just grabbing the small things that I was using so far. Just figured I would toss it your way if you want it. If not, I already have my overrides :slightly_smiling_face: 