### PR TITLE
Accomodate special case : Title attribute missing from rss

### DIFF
--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -6,6 +6,7 @@ from .models import RSSFeed
 
 import re
 
+
 class Parser:
     def __init__(self, xml: str, limit=None):
         self.xml = xml
@@ -20,10 +21,10 @@ class Parser:
 
     @staticmethod
     def check_none(
-            item: object,
-            default: str,
-            item_dict: Optional[str] = None,
-            default_dict: Optional[str] = None,
+        item: object,
+        default: str,
+        item_dict: Optional[str] = None,
+        default_dict: Optional[str] = None,
     ):
         if item:
             return item[item_dict]
@@ -32,6 +33,11 @@ class Parser:
                 return default[default_dict]
             else:
                 return default
+
+    @staticmethod
+    def get_text(item: object,
+                 attribute: str) -> str:
+        return getattr(getattr(item, attribute, ""), "text", "")
 
     def parse(self, entries: []) -> RSSFeed:
         main_soup = self.get_soup(self.xml)
@@ -54,10 +60,10 @@ class Parser:
             description_soup = self.get_soup(getattr(getattr(item, "description"), "text", ""), "html.parser")
 
             item_dict = {
-                "title": getattr(getattr(item, "title", ""), "text", ""),
-                "link": getattr(getattr(item, "link", ""), "text", ""),
-                "publish_date": getattr(getattr(item, "pubDate", ""), "text", ""),
-                "category": getattr(getattr(item, "category", ""), "text", ""),
+                "title": self.get_text(item, "title"),
+                "link": self.get_text(item, "link"),
+                "publish_date": self.get_text(item, "pubDate"),
+                "category": self.get_text(item, "category"),
                 "description": getattr(description_soup, "text", ""),
                 "description_links": [
                     anchor.get("href")
@@ -75,7 +81,7 @@ class Parser:
                 # Add user-defined entries
                 item_dict.update({"other": {}})
                 for entrie in entries:
-                    value = getattr(getattr(item, entrie, ""), "text", "")
+                    value = self.get_text(item, entrie)
                     value = re.sub(f"</?{entrie}>", "", value)
                     item_dict["other"].update({entrie: value})
 

--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -35,7 +35,7 @@ class Parser:
     def parse(self) -> RSSFeed:
         main_soup = self.get_soup(self.xml)
         self.raw_data = {
-            "title": main_soup.title.text,
+            "title": getattr(main_soup.title.text, "text", ""),
             "version": main_soup.rss.get("version"),
             "language": getattr(main_soup.language, "text", ""),
             "description": getattr(main_soup.description, "text", ""),
@@ -47,8 +47,12 @@ class Parser:
         for item in items:
             # Using html.parser instead of lxml because lxml can't parse <link>
             description_soup = self.get_soup(item.description.text, "html.parser")
+            if item.title is None:
+                title = ""
+            else:
+                title = item.title.text
             item_dict = {
-                "title": item.title.text,
+                "title": getattr(title, "text", ""),
                 "link": item.link.text,
                 "publish_date": getattr(item.pubDate, "text", ""),
                 "category": getattr(item.category, "text", ""),

--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -35,7 +35,7 @@ class Parser:
     def parse(self) -> RSSFeed:
         main_soup = self.get_soup(self.xml)
         self.raw_data = {
-            "title": getattr(main_soup.title.text, "text", ""),
+            "title": main_soup.title.text,
             "version": main_soup.rss.get("version"),
             "language": getattr(main_soup.language, "text", ""),
             "description": getattr(main_soup.description, "text", ""),
@@ -47,12 +47,12 @@ class Parser:
         for item in items:
             # Using html.parser instead of lxml because lxml can't parse <link>
             description_soup = self.get_soup(item.description.text, "html.parser")
-            if item.title is None:
+            if item.title is None:  # Makes sure to not get any AttributeError when parsing feed without title
                 title = ""
             else:
                 title = item.title.text
             item_dict = {
-                "title": getattr(title, "text", ""),
+                "title": title,
                 "link": item.link.text,
                 "publish_date": getattr(item.pubDate, "text", ""),
                 "category": getattr(item.category, "text", ""),

--- a/rss_parser/_parser.py
+++ b/rss_parser/_parser.py
@@ -1,10 +1,9 @@
+import re
 from typing import Optional
 
 from bs4 import BeautifulSoup
 
 from .models import RSSFeed
-
-import re
 
 
 class Parser:
@@ -35,8 +34,7 @@ class Parser:
                 return default
 
     @staticmethod
-    def get_text(item: object,
-                 attribute: str) -> str:
+    def get_text(item: object, attribute: str) -> str:
         return getattr(getattr(item, attribute, ""), "text", "")
 
     def parse(self, entries: []) -> RSSFeed:
@@ -57,7 +55,9 @@ class Parser:
 
         for item in items:
             # Using html.parser instead of lxml because lxml can't parse <link>
-            description_soup = self.get_soup(getattr(getattr(item, "description"), "text", ""), "html.parser")
+            description_soup = self.get_soup(
+                self.get_text(item, "description"), "html.parser"
+            )
 
             item_dict = {
                 "title": self.get_text(item, "title"),

--- a/rss_parser/models.py
+++ b/rss_parser/models.py
@@ -38,6 +38,7 @@ class FeedItem(BaseModel):
     description_images: Optional[List[DescriptionImage]]
     enclosure: Optional[Enclosure]
     itunes: Optional[Itunes]
+    other: Optional[dict]
 
     # stackoverflow.com/questions/10994229/how-to-make-an-object-properly-hashable
     # added this, so you can call/use FeedItems in a set() to avoid duplicates


### PR DESCRIPTION
When parsing a rss file, it might be possible for the item to not have any title property. I added a check for the title to be sure it does not crash any user's application. When there is no title found in the rss, the "title" property is changed to a empty string.