### PR TITLE
Add py.typed for type checkers following PEP 561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-packages = [{include = "rss_parser"}]
+packages = [
+    {include = "rss_parser"},
+    {include = "rss_parser/py.typed"},
+]
 
 
 [tool.poetry.urls]


### PR DESCRIPTION
While the `py.typed` file is missing, type checkers like mypy will treat the library as untyped when included into other projects. This behavior is defined in [PEP 561](https://peps.python.org/pep-0561/) Adding this file to the package (and ensure it gets packaged) does make the library accessible for type checkers.

To add it, I followed [this short guide](https://dev.to/whtsky/don-t-forget-py-typed-for-your-typed-python-package-2aa3).
To test it, I force-installed your package into a venv, wrote test code which uses this library, and verified that mypy now can type check everything (aka. following error is now missing: `Skipping analyzing "rss_parser": module is installed, but missing library stubs or py.typed marker  [import]`)